### PR TITLE
LET-828 - Include override consent prompt variable

### DIFF
--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -594,7 +594,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
     )
     override_consent_prompt= Boolean(
         display_name=_("Override Consent Prompt"),
-        help=_("Select True to override the consent prompt."),
+        # Translators: This is used to hide the consent for PII.
+        help=_("Select True to override PII cosent prompt visibility and hide the screen."),
         default=True,
         scope=Scope.settings
     )
@@ -729,7 +730,8 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             is_already_sharing_learner_info = (
                 self.ask_to_send_username or
                 self.ask_to_send_full_name or
-                self.ask_to_send_email
+                self.ask_to_send_email or 
+                self.override_consent_prompt
             )
             return config_service.configuration.lti_access_to_learners_editable(
                 self.scope_ids.usage_id.context_key,
@@ -1684,7 +1686,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'ask_to_send_username': self.ask_to_send_username if pii_sharing_enabled else False,
             'ask_to_send_full_name': self.ask_to_send_full_name if pii_sharing_enabled else False,
             'ask_to_send_email': self.ask_to_send_email if pii_sharing_enabled else False,
-            'override_consent_prompt': self.override_consent_prompt,
+            'override_consent_prompt': self.override_consent_prompt if pii_sharing_enabled else False,
             'button_text': self.button_text,
             'inline_height': self.inline_height,
             'modal_vertical_offset': self._get_modal_position_offset(self.modal_height),

--- a/lti_consumer/lti_xblock.py
+++ b/lti_consumer/lti_xblock.py
@@ -592,6 +592,12 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         default=False,
         scope=Scope.settings
     )
+    override_consent_prompt= Boolean(
+        display_name=_("Override Consent Prompt"),
+        help=_("Select True to override the consent prompt."),
+        default=True,
+        scope=Scope.settings
+    )
 
     enable_processors = Boolean(
         display_name=_("Send extra parameters"),
@@ -617,6 +623,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         'custom_parameters', 'launch_target', 'button_text', 'inline_height', 'modal_height',
         'modal_width', 'has_score', 'weight', 'hide_launch', 'accept_grades_past_due',
         'ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email', 'enable_processors',
+        'override_consent_prompt',
     )
 
     # Author view
@@ -636,6 +643,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                         description=""
                         ask_to_send_username="False"
                         ask_to_send_email="False"
+                        override_consent_prompt="False"
                         enable_processors="True"
                         launch_target="new_window"
                         launch_url="https://lti.tools/saltire/tp" />
@@ -645,6 +653,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
                         lti_id="test"
                         ask_to_send_username="False"
                         ask_to_send_email="False"
+                        override_consent_prompt="False"
                         enable_processors="True"
                         description=""
                         launch_target="iframe"
@@ -771,7 +780,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
         # editing of 'ask_to_send_username', 'ask_to_send_full_name', and 'ask_to_send_email'.
         pii_sharing_enabled = self.get_pii_sharing_enabled()
         if not pii_sharing_enabled:
-            noneditable_fields.extend(['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email'])
+            noneditable_fields.extend(['ask_to_send_username', 'ask_to_send_full_name', 'ask_to_send_email','override_consent_prompt'])
 
         editable_fields = tuple(
             field
@@ -1675,6 +1684,7 @@ class LtiConsumerXBlock(StudioEditableXBlockMixin, XBlock):
             'ask_to_send_username': self.ask_to_send_username if pii_sharing_enabled else False,
             'ask_to_send_full_name': self.ask_to_send_full_name if pii_sharing_enabled else False,
             'ask_to_send_email': self.ask_to_send_email if pii_sharing_enabled else False,
+            'override_consent_prompt': self.override_consent_prompt,
             'button_text': self.button_text,
             'inline_height': self.inline_height,
             'modal_vertical_offset': self._get_modal_position_offset(self.modal_height),

--- a/lti_consumer/static/js/xblock_lti_consumer.js
+++ b/lti_consumer/static/js/xblock_lti_consumer.js
@@ -168,10 +168,14 @@ function LtiConsumerXBlock(runtime, element) {
         var askToSendUsername = $ltiContainer.data('ask-to-send-username') == 'True';
         var askToSendFullName = $ltiContainer.data('ask-to-send-full-name') == 'True';
         var askToSendEmail = $ltiContainer.data('ask-to-send-email') == 'True';
+        var overrideConsentPrompt = $ltiContainer.data('override-consent-prompt') =='True';
         var ltiVersion = $ltiContainer.data('lti-version');
 
-        function renderPIIConsentPromptIfRequired(onSuccess, showCancelButton=true) {
-            if (askToSendUsername && askToSendFullName && askToSendEmail) {
+        function renderPIIConsentPromptIfRequired(onSuccess, showCancelButton = true) {
+            if (overrideConsentPrompt) {
+                onSuccess('OK');
+                return;
+            } else if (askToSendUsername && askToSendFullName && askToSendEmail) {
                 msg = gettext(
                     'Click OK to have your username, full name, and e-mail address sent to a 3rd party application.'
                 );

--- a/lti_consumer/templates/html/student.html
+++ b/lti_consumer/templates/html/student.html
@@ -19,6 +19,7 @@
     data-ask-to-send-username="${ask_to_send_username}"
     data-ask-to-send-full-name="${ask_to_send_full_name}"
     data-ask-to-send-email="${ask_to_send_email}"
+    data-override-consent-prompt="${override_consent_prompt}"
     data-lti-version="${lti_version}"
 >
 


### PR DESCRIPTION
[LET-828](https://correlation-one.atlassian.net/browse/LET-828)
Include overrideConsentPrompt on template, js and xblock definition.


https://github.com/correlation-one/xblock-lti-consumer/assets/8316977/3f850b11-47f5-4620-8a35-d26eed7a1ecd



[LET-828]: https://correlation-one.atlassian.net/browse/LET-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![image](https://github.com/correlation-one/xblock-lti-consumer/assets/8316977/f3d60d24-0677-4db9-939b-2d1ec3650ff5)
